### PR TITLE
Update config.ini - changed xbacklight at ln43 to match referant

### DIFF
--- a/dot-config/polybar/config.ini
+++ b/dot-config/polybar/config.ini
@@ -40,7 +40,7 @@ font-2 = Symbols Nerd Font Mono:size=12;2
 
 modules-left = xworkspaces spotify-prev spotify-play-pause spotify-next spotify
 modules-center = date
-modules-right = xbacklight battery pulseaudio memory cpu temperature tray
+modules-right = backlight battery pulseaudio memory cpu temperature tray
 
 tray-position = right
 


### PR DESCRIPTION
At line 43, changed "xbacklight" to "backlight" as only the latter has a referent in the config file.